### PR TITLE
Updated the delay for the compared site as well.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ This generator automates the scenarios generation process. For e.g. if you want 
 * Download this repository, and goto backstop-generator folder
 * Run `npm install`
 * Create a `.env` file inside the folder.
-   * `REFERENCE_URL` - Give the absolute URL. The screenshots from this URL will be used as base URL.
-   * `TEST_URL` - Give the absolute test URL. If this url is behind a htaccess, pass the credentials in the URL.
+   * `REFERENCE_URL` - Give the absolute reference website URL. The screenshots from this URL will be used as base URL.
+   * `REFERRED_URL` - Give the absolute referred website URL. If this url is behind a htaccess, pass the credentials in the URL.
+   * `DELAY` - Give the delay in ms. This is the time the script wait to take the screenshot.
    * `LINK_SELECTOR` - Give a selector which will be used to grab all the href tests, to run visual regression tests. Keeping it empty would take all the anchor tags from the `REFERENCE_URL`.
 * Run `npm run default` - it will generate the default configurations needed to run backstopJS.
 * Run `npm run generate` - it will generate and update the `backstop.json` file with all the scenarios.

--- a/backstopjs-generator.js
+++ b/backstopjs-generator.js
@@ -3,11 +3,12 @@ const $ = require('cheerio');
 const rp = require('request-promise');
 const fs = require('fs');
 
-const url = process.env.REFERENCE_URL;
-const testUrl = process.env.TEST_URL;
+const referenceUrl = process.env.REFERENCE_URL;
+const referredUrl = process.env.REFERRED_URL;
+const delay = process.env.DELAY || 2000;
 const selector = process.env.LINK_SELECTOR || 'a';
 
-rp(url).then(html => {
+rp(referenceUrl).then(html => {
   const linkObjects = $(selector, html);
   const links = [];
   // we only need the "href" and "title" of each link
@@ -27,13 +28,12 @@ rp(url).then(html => {
   links.forEach(function(element) {
     scenarios.push({
       "label": element.title,
-      "url": testUrl + element.href,
-      "referenceUrl": url + element.href,
-      "delay": 2000,
+      "url": referredUrl + element.href,
+      "referenceUrl": referenceUrl + element.href,
       "cookiePath": "backstop_data/engine_scripts/cookies.json",
       "readyEvent": "",
       "readySelector": "",
-      "delay": 0,
+      "delay": parseInt(delay),
       "hideSelectors": [],
       "removeSelectors": [],
       "hoverSelector": "",


### PR DESCRIPTION
1. This is to make sure both reference site and compared site both are in sync in terms of delay for loading the sites.
2. Some coding standards changes
3. Adding DELAY in the `.env` readme so that users can able to use it.